### PR TITLE
fix: make type param optional

### DIFF
--- a/src/TreeNode.ts
+++ b/src/TreeNode.ts
@@ -790,7 +790,7 @@ export class TreeNode<TTree extends Record<string, any> = Record<string, any>> {
 }
 
 /** A Tree simply extends TreeNode and can be used as the root node. */
-export class Tree<TTree extends Record<string, any>> extends TreeNode<TTree> {}
+export class Tree<TTree extends Record<string, any> = Record<string, any>> extends TreeNode<TTree> {}
 
 /**
  * A function used to check for node equality.


### PR DESCRIPTION
Thanks for the quick release last time, realised I'd make a mistake and hadn't made the type param of the tree constructor optional, only the treenode! Quick fix here for it